### PR TITLE
Fix stopping remaining background cat processes

### DIFF
--- a/tkbash
+++ b/tkbash
@@ -465,7 +465,7 @@ if ! [[ -p "$WISH_PIPE" ]]; then
 		tail_pid=$!
 		wish < "$WISH_PIPE"
 		# wish exited. clean up: remove command files, wishpipe etc.
-		kill -INT $tail_pid
+		kill -TERM $tail_pid
 		rm "${TMP}/${GUI_ID}${TMPFILE_APPENDIX}"*
 		exit 0
 	) &


### PR DESCRIPTION
Hello!

Thank you for this very good wrapper, I use it in one of my projects. There is one problem - it leaves some unfinished cat process when working. I have found out, that it is trying to stop them using SIGINT in this line: https://github.com/phil294/tkbash/blob/491d85399a80ba3847e84b7d767ee1f9c6d1ba46/tkbash#L468

However, it not always works and reasons are explained [here](https://unix.stackexchange.com/questions/372541/why-doesnt-sigint-work-on-a-background-process-in-a-script).

So I changed SIGINT to SIGTERM and it seems to work just fine!